### PR TITLE
Use networking.k8s.io/v1 nd networking.k8s.io/v1beta1

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: qliksense-operator
           # Replace this with the built image name, please keep it as the release version
-          image: qlik-docker-oss.bintray.io/qliksense-operator:v0.2.3
+          image: qlik-docker-oss.bintray.io/qliksense-operator:v0.2.4
           command:
           - qliksense-operator
           imagePullPolicy: Always

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - deployments
+  - replicasets
   - pods
   - services
   - services/finalizers
@@ -17,13 +25,7 @@ rules:
   - secrets
   - serviceaccounts
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - apps
   resources:
@@ -33,13 +35,7 @@ rules:
   - statefulsets
   - deployments/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -52,62 +48,36 @@ rules:
   resources:
   - '*'
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - extensions
+  - networking.k8s.io
   resources:
   - ingresses
   - networkpolicies
+  - ingresses/status
   - deployments
+  - replicasets
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - batch
   resources:
   - cronjobs
   - jobs
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
   - rolebindings
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - qixmanager.qlik.com
   resources:
   - engines
+  - engines/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'

--- a/pkg/controller/qliksense/owner_update.go
+++ b/pkg/controller/qliksense/owner_update.go
@@ -9,7 +9,8 @@ import (
 	batch_v1 "k8s.io/api/batch/v1"
 	batch_v1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	networking_v1 "k8s.io/api/networking/v1"
+	networking_v1beta1 "k8s.io/api/networking/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -164,7 +165,7 @@ func (r *ReconcileQliksense) updateStatefulSetOwner(reqLogger logr.Logger, q *ql
 
 func (r *ReconcileQliksense) updateIngressOwner(reqLogger logr.Logger, q *qlikv1.Qliksense) error {
 
-	listObj := &v1beta1.IngressList{}
+	listObj := &networking_v1beta1.IngressList{}
 	if err := r.client.List(context.TODO(), listObj, client.MatchingLabels{searchingLabel: q.Name}); err != nil {
 		return err
 	}
@@ -409,7 +410,7 @@ func (r *ReconcileQliksense) updateRoleBindingOwner(reqLogger logr.Logger, q *ql
 
 func (r *ReconcileQliksense) updateNetworkPolicyOwner(reqLogger logr.Logger, q *qlikv1.Qliksense) error {
 
-	listObj := &v1beta1.NetworkPolicyList{}
+	listObj := &networking_v1.NetworkPolicyList{}
 	if err := r.client.List(context.TODO(), listObj, client.MatchingLabels{searchingLabel: q.Name}); err != nil {
 		return err
 	}

--- a/pkg/controller/qliksense/qliksense_extra_resources.go
+++ b/pkg/controller/qliksense/qliksense_extra_resources.go
@@ -159,6 +159,7 @@ func (r *ReconcileQliksense) updateJobPodSpec(podSpec *corev1.PodSpec, reqLogger
 		}
 	}
 	podSpec.RestartPolicy = corev1.RestartPolicy(podSpecRestartPolicy)
+	podSpec.ServiceAccountName = "qliksense-operator"
 	updateJobPodSpecForImageRegistry(m, podSpec)
 	return nil
 }


### PR DESCRIPTION
Using networking.k8s.io/v1 for NetworkPolicy and networking.k8s.io/v1beta1 for Ingress.

On kubernetes v1.16, operator takes ownership of resources without errors and cleans them up on CR deletion.

 